### PR TITLE
Fix Doom (GBA) and Donkey Kong Country (GBA) on forks

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,9 +249,9 @@
 -
 <a href="example/sm3.html">Super Mario Bros. 3 (NES)</a>
  -
-<a href="https://cbgamesdev.github.io/chilibowlflash/GBA-gh-pages/launcher.html#dkc">Donkey Kong Country (GBA)</a>
+<a href="GBA-gh-pages/launcher.html#dkc">Donkey Kong Country (GBA)</a>
 -
-<a href="https://cbgamesdev.github.io/chilibowlflash/GBA-gh-pages/launcher.html#dm">DOOM (GBA)</a>
+<a href="GBA-gh-pages/launcher.html#dm">DOOM (GBA)</a>
 -	
 <a href="GBA-gh-pages/launcher.html#gta">Grand Theft Auto (GBA)</a>
 -


### PR DESCRIPTION
Make it point to a local file so that it doesn’t get blocked

As of now, chiboga.github.io points to this website’s version, making it be blocked